### PR TITLE
Deploy contract

### DIFF
--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -48,7 +48,6 @@ function Start() {
       setEthersContext(state => ({ ...ethersContext, contract: contract}));
     } catch (error) {
       console.log(error);
-      console.log(error.reason === "User rejected provider access")
     }
   }
 

--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -20,7 +20,8 @@ function Start() {
       || (typeof window.web3 !== 'undefined')) {
       // Web3 browser user detected. You can now use the provider.
       let provider = window['ethereum'] || window.web3.currentProvider
-      provider = new ethers.providers.Web3Provider(provider);
+      //NOTE: must wrap window.etherm to get provider, not window.web3
+      provider = new ethers.providers.Web3Provider(window.ethereum);
       setEthersContext(state => ({ ...ethersContext, provider }));
     }
   }, []);
@@ -38,12 +39,9 @@ function Start() {
       }
 
       //deploy the contract here
-      let signer = ethersContext.getSigner(0);
-      console.log("output");
-      console.log("signer: " + signer);
-      let factory = new ethersContext.ContractFactory(HangmanContract.abi, HangmanContract.bytecode);
-      console.log("factory: " + factory);
-      
+      const signer = ethersContext.provider.getSigner();
+      let factory = new ethers.ContractFactory(HangmanContract.abi, HangmanContract.bytecode, signer);
+      let contract = await factory.deploy("hello", 10);
     } catch (error) {
       console.log(error);
       console.log(error.reason === "User rejected provider access")

--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -45,6 +45,7 @@ function Start() {
       //can I do hex with ethers? or do I need to use web 0.20?
       let hex = window.web3.toHex("hello");
       let contract = await factory.deploy(hex, 10);
+      setEthersContext(state => ({ ...ethersContext, contract: contract}));
     } catch (error) {
       console.log(error);
       console.log(error.reason === "User rejected provider access")

--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -38,10 +38,14 @@ function Start() {
       }
 
       //deploy the contract here
+      let signer = ethersContext.getSigner(0);
+      console.log("output");
+      console.log("signer: " + signer);
       let factory = new ethersContext.ContractFactory(HangmanContract.abi, HangmanContract.bytecode);
-      console.log(factory);
+      console.log("factory: " + factory);
       
     } catch (error) {
+      console.log(error);
       console.log(error.reason === "User rejected provider access")
     }
   }

--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -18,6 +18,7 @@ function Start() {
   useEffect(() => {
     if (typeof window.ethereum !== 'undefined'
       || (typeof window.web3 !== 'undefined')) {
+      console.log(window.web3.version);
       // Web3 browser user detected. You can now use the provider.
       let provider = window['ethereum'] || window.web3.currentProvider
       //NOTE: must wrap window.etherm to get provider, not window.web3
@@ -41,7 +42,9 @@ function Start() {
       //deploy the contract here
       const signer = ethersContext.provider.getSigner();
       let factory = new ethers.ContractFactory(HangmanContract.abi, HangmanContract.bytecode, signer);
-      let contract = await factory.deploy("hello", 10);
+      //can I do hex with ethers? or do I need to use web 0.20?
+      let hex = window.web3.toHex("hello");
+      let contract = await factory.deploy(hex, 10);
     } catch (error) {
       console.log(error);
       console.log(error.reason === "User rejected provider access")

--- a/web/src/Start.js
+++ b/web/src/Start.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { EthersContext } from './EthersContext.js';
 import { ethers } from 'ethers';
+import HangmanContract from './contracts/Hangman.json';
 
 function Start() {
   const [ethersContext, setEthersContext] = useContext(EthersContext);
@@ -35,6 +36,11 @@ function Start() {
       } else {
         console.log("Selected Address is: " + selectedAddress);
       }
+
+      //deploy the contract here
+      let factory = new ethersContext.ContractFactory(HangmanContract.abi, HangmanContract.bytecode);
+      console.log(factory);
+      
     } catch (error) {
       console.log(error.reason === "User rejected provider access")
     }


### PR DESCRIPTION
## Description
Add in the functionality to deploy a contract

## Changes
This adds in the functionality to deploy a contract through ethers.js using the metamask provider
Successfully opens the deploy window and saves the deployed contract to to the context.