### PR TITLE
Chainlink 0.4.24

### DIFF
--- a/contracts/Imports.sol
+++ b/contracts/Imports.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+// We import the contract so truffle compiles it, and we have the ABI 
+// available when working from truffle console.
+import "@gnosis.pm/mock-contract/contracts/MockContract.sol";
+import "chainlink/contracts/Oracle.sol";
+import "link_token/contracts/LinkToken.sol";

--- a/contracts/StartGame.sol
+++ b/contracts/StartGame.sol
@@ -12,7 +12,6 @@ contract StartGame is ChainlinkClient, Ownable {
 
     string public url;
     string public path;
-    address public oracleAddr;
     bytes32 public constant CHAINLINK_JOB_ID = "013f25963613411badc2ece3a92d0800";
     mapping(bytes32 => Game) public requestIdToGame;
 

--- a/contracts/StartGame.sol
+++ b/contracts/StartGame.sol
@@ -47,11 +47,25 @@ contract StartGame is ChainlinkClient, Ownable {
             require(gameInstance.player != 0, "Id does not exist");
 
             //create the new hangman with the word(data)
-            Hangman game = new Hangman(abi.encodePacked(_data), _data.length);
+            Hangman game = new Hangman(bytes32ToBytes(_data), _data.length);
             //save game into the request
             gameInstance.game = game;
             //update the owner of the game
             game.transferOwnership(gameInstance.player);
+    }
+
+    function bytes32ToBytes(bytes32 data) private pure returns (bytes) {
+        uint i = 0;
+        while (i < 32 && uint(data[i]) != 0) {
+            ++i;
+        }
+        bytes memory result = new bytes(i);
+        i = 0;
+        while (i < 32 && data[i] != 0) {
+            result[i] = data[i];
+            ++i;
+        }
+        return result;
     }
 
     function withdrawLink() public onlyOwner {

--- a/contracts/StartGame.sol
+++ b/contracts/StartGame.sol
@@ -5,10 +5,19 @@ import "chainlink/contracts/ChainlinkClient.sol";
 import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
 contract StartGame is ChainlinkClient, Ownable {
+    struct Game {
+        address player;
+        address game;
+    }
+
     string public url;
     string public path;
     address public oracleAddr;
     bytes32 public constant CHAINLINK_JOB_ID = "013f25963613411badc2ece3a92d0800";
+    mapping(bytes32 => GameRequest) public requestIdToGame;
+
+    //map job id to game struct
+    //game struct will have address of the owner of that game and the hangman address
 
     constructor(address _link, address _oracle, string _url, string _path) public {
         setChainlinkToken(_link);
@@ -17,20 +26,32 @@ contract StartGame is ChainlinkClient, Ownable {
         path = _path;
     }
 
-    function createWordRequest(uint256 payment) internal returns (bytes32) {
+    function requestStartGame(uint256 payment) public returns (bytes32) {
         // newRequest takes a JobID, a callback address, and callback function as input
-        Chainlink.Request memory req = buildChainlinkRequest(CHAINLINK_JOB_ID, this, this.fulfill.selector);
+        Chainlink.Request memory req = buildChainlinkRequest(CHAINLINK_JOB_ID, this, this.fullfillStartGame.selector);
         req.add("url", url);
         req.add("path", path);
-        bytes32 requestId = sendChainlinkRequestTo(chainlinkOracleAddress(), req, payment);
+        bytes32 requestId = sendChainlinkRequest(req, payment);
+        //requestId will point to the player and the game address(which is pending)
+        requestIdToGame[requestId] = Game(msg.sender, address(0));
+        //return request id as to check if we've gotten a game back
         return requestId;
     }
 
-    function fulfill(bytes32 _requestId, bytes32 _data)
+    function fullfillStartGame(bytes32 _requestId, bytes32 _data)
         public
         recordChainlinkFulfillment(_requestId)
         returns (bytes32) {
-        return _data;
+            require(requestIdToGame[_requestId] != 0, "Id does not exist");
+
+            //get the game instance
+            Game storage gameInstance = requestIdToGame[_requestId];
+            //create the new hangman with the word(data)
+            Hangman game = new Hangman(_data, _data.length);
+            //save game into the request
+            gameInstance.game = game;
+            //update the owner of the game
+            game.transferOwnership(gameInstance.player);
     }
 
     function withdrawLink() public onlyOwner {
@@ -44,12 +65,5 @@ contract StartGame is ChainlinkClient, Ownable {
 
     function cancelRequest(bytes32 _requestId, uint256 _payment, bytes4 _callbackFunctionId, uint256 _expiration) public onlyOwner {
         cancelChainlinkRequest(_requestId, _payment, _callbackFunctionId, _expiration);
-    }
-
-    function createHangmanContract() public returns (address) {
-        bytes memory word = "cheese";
-        Hangman game = new Hangman(word, word.length);
-        game.transferOwnership(msg.sender);
-        return address(game);
     }
 }

--- a/contracts/StartGame.sol
+++ b/contracts/StartGame.sol
@@ -14,7 +14,7 @@ contract StartGame is ChainlinkClient, Ownable {
     string public path;
     address public oracleAddr;
     bytes32 public constant CHAINLINK_JOB_ID = "013f25963613411badc2ece3a92d0800";
-    mapping(bytes32 => GameRequest) public requestIdToGame;
+    mapping(bytes32 => Game) public requestIdToGame;
 
     //map job id to game struct
     //game struct will have address of the owner of that game and the hangman address
@@ -42,12 +42,13 @@ contract StartGame is ChainlinkClient, Ownable {
         public
         recordChainlinkFulfillment(_requestId)
         returns (bytes32) {
-            require(requestIdToGame[_requestId] != 0, "Id does not exist");
-
             //get the game instance
             Game storage gameInstance = requestIdToGame[_requestId];
+
+            require(gameInstance.player != 0, "Id does not exist");
+
             //create the new hangman with the word(data)
-            Hangman game = new Hangman(_data, _data.length);
+            Hangman game = new Hangman(abi.encodePacked(_data), _data.length);
             //save game into the request
             gameInstance.game = game;
             //update the owner of the game

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "scripts": {
+    "truffle-version": "truffle version",
     "truffle-migrate": "truffle migrate",
     "truffle-compile": "truffle compile",
     "truffle-test": "yarn clean && yarn truffle-migrate && truffle test",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "truffle-migrate": "truffle migrate",
     "truffle-compile": "truffle compile",
-    "truffle-test": "truffle test",
+    "truffle-test": "yarn clean && yarn truffle-migrate && truffle test",
     "ganache": "ganache-cli -d",
     "web:start": "cd ./web && npm start",
     "web:test": "cd ./web && npm test",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "truffle-version": "truffle version",
     "truffle-migrate": "truffle migrate",
     "truffle-compile": "truffle compile",
-    "truffle-test": "yarn clean && yarn truffle-migrate && truffle test",
+    "truffle-test": "yarn clean; yarn truffle-migrate && truffle test",
     "ganache": "ganache-cli -d",
     "web:start": "cd ./web && npm start",
     "web:test": "cd ./web && npm test",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "ganache-cli": "6.4.3"
   },
   "dependencies": {
-    "ganache-time-traveler": "github:ejwessel/GanacheTimeTraveler",
+    "@gnosis.pm/mock-contract": "2.0.4",
     "chainlink": "^0.6.4",
+    "ganache-time-traveler": "github:ejwessel/GanacheTimeTraveler",
     "openzeppelin-solidity": "1.12.0",
     "truffle": "^5.0.19",
     "truffle-assertions": "^0.9.0",

--- a/test/Hangman.test.js
+++ b/test/Hangman.test.js
@@ -8,13 +8,14 @@ contract('Hangman', async (accounts) => {
 
     const player = accounts[0];
     var hangmanContract;
+    let snapshotId;
 
     before(async() => {
         hangmanContract = await Hangman.new(web3.fromAscii("hello"), 5);
     });
 
     beforeEach(async() => {
-        snapShot = await helper.takeSnapshot();
+        let snapShot = await helper.takeSnapshot();
         snapshotId = snapShot['result'];
     });
 

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -10,8 +10,7 @@ const web3 = utils.getWeb3();
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-contract('StartGame', async (accounts) => {
-
+contract.only('StartGame', async (accounts) => {
   let startGame;
   let mockLinkToken;
   let mockOracle = accounts[9];
@@ -22,9 +21,6 @@ contract('StartGame', async (accounts) => {
   before('deploy StartGame', async() => {
       let linkTokenTemplate = await LinkToken.new();
       mockLinkToken = await MockContract.new();
-
-      let oracleTemplate = await Oracle.new(EMPTY_ADDRESS);
-      mockOracle = await MockContract.new();
 
       //mock LinkToken.transferAndCall()
       let mockLink_transferAndCall = 
@@ -50,7 +46,7 @@ contract('StartGame', async (accounts) => {
     })
   });
 
-  describe.only("Test creation of hangman contract game", async () => {
+  describe("Test creation of hangman contract game", async () => {
     it("Test requestStartGame is successful in requesting to start a game", async() => {
         //perform a mock call to ensure we get a requestId
         let requestId = await startGame.requestStartGame.call(1);
@@ -63,7 +59,7 @@ contract('StartGame', async (accounts) => {
         assert.equal(game[1], EMPTY_ADDRESS, "saving game instance was unsuccessful");
     });
     
-    it("Test that hangman contract was created", async() => {
+    it("Test fullfillStartGame is susccessful in creating a Hangman contract", async() => {
         let requestId = await startGame.requestStartGame.call(1);
         let trx = await startGame.requestStartGame(1);
       
@@ -77,9 +73,10 @@ contract('StartGame', async (accounts) => {
 
         let hangman = await Hangman.at(game[1]);
         let owner = await hangman.owner.call();
-        console.log(owner);
-        console.log(player);
         assert.equal(owner, player, "player is not the owner of hangman contract");
+
+        trx = await hangman.makeWordGuess(web3.toHex("testing"));
+        console.log(trx);
     });
   });
 });

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -17,6 +17,7 @@ contract('StartGame', async (accounts) => {
   let player = accounts[0];
   let url = "https://en.wikipedia.org/api/rest_v1/page/random/title";
   let path = "items[0].title";
+  let snapshotId;
 
   before('deploy StartGame', async() => {
       let linkTokenTemplate = await LinkToken.new();
@@ -30,6 +31,15 @@ contract('StartGame', async (accounts) => {
       await mockLinkToken.givenMethodReturnBool(mockLink_transferAndCall, true);
 
       startGame = await StartGame.new(mockLinkToken.address, mockOracle, url, path);
+  });
+
+  beforeEach(async() => {
+    let snapShot = await helper.takeSnapshot();
+    snapshotId = snapShot['result'];
+  });
+
+  afterEach(async() => {
+      await helper.revertToSnapShot(snapshotId);
   });
 
   describe("Test initial values", async () => {

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -10,7 +10,7 @@ const web3 = utils.getWeb3();
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-contract.only('StartGame', async (accounts) => {
+contract('StartGame', async (accounts) => {
   let startGame;
   let mockLinkToken;
   let mockOracle = accounts[9];
@@ -59,13 +59,13 @@ contract.only('StartGame', async (accounts) => {
         assert.equal(game[1], EMPTY_ADDRESS, "saving game instance was unsuccessful");
     });
     
-    it("Test fullfillStartGame is susccessful in creating a Hangman contract", async() => {
+    it.only("Test fullfillStartGame is susccessful in creating a Hangman contract", async() => {
         let requestId = await startGame.requestStartGame.call(1);
         let trx = await startGame.requestStartGame(1);
       
         //call the fullfillStartGame with data that mocks
-        let bytesVal = web3.toHex("testing");
-        console.log(bytesVal);
+        let givenWord = "testing";
+        let bytesVal = web3.toHex(givenWord);
         await startGame.fullfillStartGame(requestId, bytesVal, { from: mockOracle });
         let game = await startGame.requestIdToGame(requestId);
         assert.equal(game[0], player, "saving game instance was unsuccessful");
@@ -76,7 +76,7 @@ contract.only('StartGame', async (accounts) => {
         assert.equal(owner, player, "player is not the owner of hangman contract");
 
         trx = await hangman.makeWordGuess(web3.toHex("testing"));
-        console.log(trx);
+        truffleAssert.eventEmitted(trx, "GameWin");
     });
   });
 });

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -1,5 +1,8 @@
 const StartGame = artifacts.require("StartGame");
 const Hangman = artifacts.require("Hangman");
+const Oracle = artifacts.require("Oracle");
+const LinkToken = artifacts.require("LinkToken");
+const MockContract = artifacts.require("MockContract");
 const helper = require('ganache-time-traveler');
 const truffleAssert = require('truffle-assertions');
 const utils = require('./utils.js');
@@ -10,13 +13,26 @@ const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 contract('StartGame', async (accounts) => {
 
   let startGame;
+  let mockLinkToken;
+  let mockOracle;
   let linkTokenAddress = accounts[2];
   let oracleAddress = accounts[3];
   let url = "https://en.wikipedia.org/api/rest_v1/page/random/title";
   let path = "items[0].title";
 
   before('deploy StartGame', async() => {
-      startGame = await StartGame.new(linkTokenAddress, oracleAddress, url, path);
+      let linkTokenTemplate = await LinkToken.new();
+      let mockLinkToken = await MockContract.new();
+
+      let oracleTemplate = await Oracle.new(0);
+      let mockOracle = await MockContract.new();
+
+      //mock LinkToken.transferAndCall()
+      let mockLink_transferAndCall = 
+        linkTokenTemplate.contract.methods.transferAndCall(0, 0, 0).encodeABI();
+      await mockLinkToken.givenMethodReturnBool(mockLink_transferAndCall, true);
+
+      startGame = await StartGame.new(mockLinkToken.address, mockOracle.address, url, path);
   });
 
   describe("Test initial values", async () => {
@@ -33,18 +49,24 @@ contract('StartGame', async (accounts) => {
     })
   });
 
-  describe("Test createHangmanContact", async () => {
+  describe("Test creatHangmanContact", async () => {
     it("Test createHangmanContract does not return empty address", async() => {
+        let startGame = await StartGame.new();
         let address = await startGame.createHangmanContract.call();
         assert.notEqual(address, EMPTY_ADDRESS, "address is not the null address");
     });
     
     it("Test owner of deployed contact", async() => {
-        let address = await startGame.createHangmanContract.call();
-        let trx = await startGame.createHangmanContract();
-        let hangmanContract = await Hangman.at(address);
-        let owner = await hangmanContract.owner.call();
-        assert.equal(owner, accounts[0], "Is owner should be true");
+        let startGame = await StartGame.new();
+        let requestId = await startGame.requestStartGame.call();
+
+        console.log(requestId);
+
+        let trx = await startGame.requestStartGame();;
+
+        //let hangmanContract = await Hangman.at(address);
+        //let isOwner = await hangmanContract.isOwner.call();
+        //assert.equal(isOwner, true, "Is owner should be true");
     });
   });
 });

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -10,7 +10,7 @@ const web3 = utils.getWeb3();
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-contract('StartGame', async (accounts) => {
+contract.only('StartGame', async (accounts) => {
 
   let startGame;
   let mockLinkToken;
@@ -24,12 +24,14 @@ contract('StartGame', async (accounts) => {
       let linkTokenTemplate = await LinkToken.new();
       let mockLinkToken = await MockContract.new();
 
-      let oracleTemplate = await Oracle.new(0);
+      let oracleTemplate = await Oracle.new(EMPTY_ADDRESS);
       let mockOracle = await MockContract.new();
 
       //mock LinkToken.transferAndCall()
       let mockLink_transferAndCall = 
-        linkTokenTemplate.contract.methods.transferAndCall(0, 0, 0).encodeABI();
+        linkTokenTemplate.contract.methods
+          .transferAndCall(EMPTY_ADDRESS, 0, web3.toHex("0"))
+          .encodeABI();
       await mockLinkToken.givenMethodReturnBool(mockLink_transferAndCall, true);
 
       startGame = await StartGame.new(mockLinkToken.address, mockOracle.address, url, path);
@@ -51,18 +53,16 @@ contract('StartGame', async (accounts) => {
 
   describe("Test creatHangmanContact", async () => {
     it("Test createHangmanContract does not return empty address", async() => {
-        let startGame = await StartGame.new();
-        let address = await startGame.createHangmanContract.call();
-        assert.notEqual(address, EMPTY_ADDRESS, "address is not the null address");
+        //let address = await startGame.createHangmanContract.call();
+        //assert.notEqual(address, EMPTY_ADDRESS, "address is not the null address");
     });
     
     it("Test owner of deployed contact", async() => {
-        let startGame = await StartGame.new();
-        let requestId = await startGame.requestStartGame.call();
+        let requestId = await startGame.requestStartGame.call(1);
 
         console.log(requestId);
 
-        let trx = await startGame.requestStartGame();
+        //let trx = await startGame.requestStartGame();
 
         //let hangmanContract = await Hangman.at(address);
         //let isOwner = await hangmanContract.isOwner.call();

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -1,8 +1,8 @@
 const StartGame = artifacts.require("StartGame");
 const Hangman = artifacts.require("Hangman");
+const MockContract = artifacts.require("MockContract");
 const Oracle = artifacts.require("Oracle");
 const LinkToken = artifacts.require("LinkToken");
-const MockContract = artifacts.require("MockContract");
 const helper = require('ganache-time-traveler');
 const truffleAssert = require('truffle-assertions');
 const utils = require('./utils.js');
@@ -62,7 +62,7 @@ contract('StartGame', async (accounts) => {
 
         console.log(requestId);
 
-        let trx = await startGame.requestStartGame();;
+        let trx = await startGame.requestStartGame();
 
         //let hangmanContract = await Hangman.at(address);
         //let isOwner = await hangmanContract.isOwner.call();

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -26,7 +26,7 @@ contract('StartGame', async (accounts) => {
       //mock LinkToken.transferAndCall()
       let mockLink_transferAndCall = 
         linkTokenTemplate.contract.methods
-          .transferAndCall(EMPTY_ADDRESS, 0, web3.toHex("0"))
+          .transferAndCall(EMPTY_ADDRESS, 0, web3.fromAscii("0"))
           .encodeABI();
       await mockLinkToken.givenMethodReturnBool(mockLink_transferAndCall, true);
 
@@ -73,7 +73,7 @@ contract('StartGame', async (accounts) => {
       
         //call the fullfillStartGame with data that mocks
         let givenWord = "testing";
-        let bytesVal = web3.toHex(givenWord);
+        let bytesVal = web3.fromAscii(givenWord);
         await startGame.fullfillStartGame(requestId, bytesVal, { from: mockOracle });
         let game = await startGame.requestIdToGame(requestId);
         assert.equal(game[0], player, "saving game instance was unsuccessful");
@@ -83,7 +83,7 @@ contract('StartGame', async (accounts) => {
         let owner = await hangman.owner.call();
         assert.equal(owner, player, "player is not the owner of hangman contract");
 
-        trx = await hangman.makeWordGuess(web3.toHex("testing"));
+        trx = await hangman.makeWordGuess(web3.fromAscii("testing"));
         truffleAssert.eventEmitted(trx, "GameWin");
     });
   });

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -34,15 +34,13 @@ contract('StartGame', async (accounts) => {
 
   describe("Test initial values", async () => {
     it("Test url", async() => {
+        let val = await startGame.url.call();
+        assert.equal(val, url, "url not properly set");
     })
     
     it("Test path", async() => {
-    })
-
-    it("Test chainlink token address", async() => {
-    })
-
-    it("Test oracle address", async() => {
+        let val = await startGame.path.call();
+        assert.equal(val, path, "path not properly set");
     })
   });
 
@@ -59,7 +57,7 @@ contract('StartGame', async (accounts) => {
         assert.equal(game[1], EMPTY_ADDRESS, "saving game instance was unsuccessful");
     });
     
-    it.only("Test fullfillStartGame is susccessful in creating a Hangman contract", async() => {
+    it("Test fullfillStartGame is susccessful in creating a Hangman contract", async() => {
         let requestId = await startGame.requestStartGame.call(1);
         let trx = await startGame.requestStartGame(1);
       

--- a/test/StartGame.test.js
+++ b/test/StartGame.test.js
@@ -51,10 +51,10 @@ contract.only('StartGame', async (accounts) => {
     })
   });
 
-  describe("Test creatHangmanContact", async () => {
-    it("Test createHangmanContract does not return empty address", async() => {
-        //let address = await startGame.createHangmanContract.call();
-        //assert.notEqual(address, EMPTY_ADDRESS, "address is not the null address");
+  describe("Test createHangmanContract", async () => {
+    it("Test requestStartGame returns a requestId", async() => {
+        let requestId = await startGame.requestStartGame.call(1);
+        assert.isOk(requestId, "a request id was not returned");
     });
     
     it("Test owner of deployed contact", async() => {


### PR DESCRIPTION
## Description
We needed to downgrade to `solidity ^0.4.24;` because chainlink contracts are stuck on that version. 
This makes it difficult to use `pragma solidity ^0.5.0;`
This PR handles this downgrade and all related changes. It also mocks chainlink contracts.

## Changes
- mock `requestStartGame`
- mock `fullfillStartGame`
- addition of tracking of chainlink requests made from `StartGame.sol`
